### PR TITLE
Feature/pod-annotations

### DIFF
--- a/charts/dsb-spring-boot/Chart.yaml
+++ b/charts/dsb-spring-boot/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.6
+version: 3.0.7

--- a/charts/dsb-spring-boot/templates/deployment.yaml
+++ b/charts/dsb-spring-boot/templates/deployment.yaml
@@ -19,18 +19,27 @@ spec:
       labels:
         app: {{ .Release.Name }}-app
       annotations:
-        "apparmor.security.beta.kubernetes.io/pod": "runtime/default"
-        "prometheus.io/scrape": {{ .Values.prometheus_enabled | quote }}
-        "prometheus.io/port": {{ .Values.prometheus_port | quote }}
-        "prometheus.io/path": {{ .Values.prometheus_path | quote }}
-        # We change this annotation on change in chart or parameters, to force re-create of pods (to pick up config changes etc)
-        # We create a string based on the chart version, and the resolved configuration values.
-        # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum: "chart-version={{ .Chart.Version }}_config-hash={{ .Values | toString | sha256sum }}"
-        co.elastic.logs/json.keys_under_root: "true"
-        co.elastic.logs/json.overwrite_keys: "true"
-        co.elastic.logs/json.add_error_key: "true"
-        co.elastic.logs/json.message_key: "message"
+        {{- /*
+        protected pod annotations:
+          checksum: Required for proper pod creation, see below
+          prometheus.io/*: Should not be overwritable as these are defined as separate values (with defaults) in values.yaml
+        */}}
+        {{- $protectedAnnotations := dict   "checksum"              (print "chart-version=" .Chart.Version "_config-hash=" (.Values | toString | sha256sum) ) }}
+        {{- $_ := set $protectedAnnotations "prometheus.io/scrape"  .Values.prometheus_enabled }}
+        {{- $_ := set $protectedAnnotations "prometheus.io/port"    .Values.prometheus_port }}
+        {{- $_ := set $protectedAnnotations "prometheus.io/path"    .Values.prometheus_path }}
+        {{- /*
+        Final pod annotations are the result of proteced merged with overrides, where protected takes precedence */}}
+        {{- $podAnnotations := .Values.podAnnotations }} {{- /* <-- Required to define as variable to support 'podAnnotations: null' */}}
+        {{- $merged := mustMergeOverwrite $podAnnotations $protectedAnnotations }}
+        {{- range $key, $val := $merged }}
+        {{- if $key | eq "checksum" }}
+        # checksum anntotation:
+        #   We change this annotation on change in chart or parameters, to force re-create of pods (to pick up config changes etc)
+        #   We create a string based on the chart version, and the resolved configuration values.
+        #   See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments{{- end }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Release.Name }}-service-account
       nodeSelector:

--- a/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
@@ -87,7 +87,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=3.0.6_config-hash=3834b6b97f50ae211a16c1fa1866f5ab43c3f980b17dc552bc063e6427961344
+            checksum: chart-version=3.0.7_config-hash=55bfd54f90c75501a43801b8c4fd55b20938a09dcf69e7c59a57a34e1c6ca789
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -142,7 +142,7 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=3.0.6_config-hash=3834b6b97f50ae211a16c1fa1866f5ab43c3f980b17dc552bc063e6427961344
+            checksum: chart-version=3.0.7_config-hash=fb378eae67431dc6bde1d674d4023c06b9daca2de00879348685b703f7872188
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.message_key: message
@@ -270,7 +270,7 @@ Full manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-spring-boot
-        chart-version: 3.0.6
+        chart-version: 3.0.7
         management.port: "81"
         spring-boot: "true"
       name: RELEASE-NAME
@@ -305,7 +305,7 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=3.0.6_config-hash=4ad1b4070a569cc2226b5cc7269c0ee782f59fc78252d57043d5c05a713f2aef
+            checksum: chart-version=3.0.7_config-hash=eb36f716c180bda06e49470944d35c4e23e06f84a63b67a244e19684114d1388
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.message_key: message
@@ -401,7 +401,7 @@ Minimal manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-spring-boot
-        chart-version: 3.0.6
+        chart-version: 3.0.7
         management.port: "8180"
         spring-boot: "true"
       name: RELEASE-NAME

--- a/charts/dsb-spring-boot/tests/pod_annotations_test.yaml
+++ b/charts/dsb-spring-boot/tests/pod_annotations_test.yaml
@@ -1,0 +1,61 @@
+suite: test pod annotations
+templates:
+  - deployment.yaml
+tests:
+  - it: should support custom pod annotations
+    set:
+      podAnnotations:
+        custom-key: custom value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.[custom-key]
+          value: custom value
+  - it: should support overriding default pod annotations
+    set:
+      podAnnotations:
+        co.elastic.logs/json.keys_under_root: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.[co.elastic.logs/json.keys_under_root]
+          value: "false"
+  - it: should support removing default pod annotations
+    set:
+      podAnnotations:
+        co.elastic.logs/json.keys_under_root: null
+    asserts:
+      - isNull:
+          path: spec.template.metadata.annotations.[co.elastic.logs/json.keys_under_root]
+  - it: should support removing all default pod annotations
+    set:
+      podAnnotations: null
+    asserts:
+      - isNull:
+          path: spec.template.metadata.annotations.[apparmor.security.beta.kubernetes.io/pod]
+      - isNull:
+          path: spec.template.metadata.annotations.[co.elastic.logs/json.keys_under_root]
+      - isNull:
+          path: spec.template.metadata.annotations.[co.elastic.logs/json.overwrite_keys]
+      - isNull:
+          path: spec.template.metadata.annotations.[co.elastic.logs/json.add_error_key]
+      - isNull:
+          path: spec.template.metadata.annotations.[co.elastic.logs/json.message_key]
+  - it: should not overwrite protected pod annotations
+    set:
+      podAnnotations:
+        checksum: "custom value"
+    asserts:
+      - notEqual:
+          path: spec.template.metadata.annotations.checksum
+          value: "custom value"
+  - it: should not remove protected pod annotations
+    set:
+      podAnnotations: null
+    asserts:
+      - isNotNull:
+          path: spec.template.metadata.annotations.checksum
+      - isNotNull:
+          path: spec.template.metadata.annotations.[prometheus.io/path]
+      - isNotNull:
+          path: spec.template.metadata.annotations.[prometheus.io/port]
+      - isNotNull:
+          path: spec.template.metadata.annotations.[prometheus.io/scrape]

--- a/charts/dsb-spring-boot/values.yaml
+++ b/charts/dsb-spring-boot/values.yaml
@@ -17,6 +17,21 @@ deploymentAnnotations: {}
 # Annotations to put on every CronJob:
 cronJobAnnotations: {}
 
+# Annotations to put on every pod:
+# Usage when applying with values.yaml
+# podAnnotations:
+#   my-custom-key: "my custom value"                  # add custom annotation
+#   co.elastic.logs/json.message_key: "my_override"   # override a default
+#   co.elastic.logs/json.keys_under_root: null        # remove a default
+# To remove all defaults and not specify any annotations:
+# podAnnotations: null                                # Note that using empty map {} will not work
+podAnnotations:
+  apparmor.security.beta.kubernetes.io/pod: "runtime/default"
+  co.elastic.logs/json.keys_under_root: "true"
+  co.elastic.logs/json.overwrite_keys: "true"
+  co.elastic.logs/json.add_error_key: "true"
+  co.elastic.logs/json.message_key: "message"
+
 # Default Spring Profile:
 springProfiles: "kubernetes"
 


### PR DESCRIPTION
# Fixes:
- dsb-spring-boot: empty map/dictionary syntax:
  - yaml nodes that are default empty and assued to be defined as map/dictionaries in the template should also be initialized as map/dictionaries. Not empty arrays. Achieved using yaml flow mapping.

# New features:
- dsb-spring-boot: pod annotations
  - Pod annotations are now dynamic and configurable via input values.
  - Supports adding custom annotations, overriding default annotation(s) and removing default annotation(s).
  - Some annotations are considered protected and are thus not removable/overwriteable. This is to ensure core functionality of the chart. These are:
    - The `checksum` annotation, ensures proper pod (re-)creation.
    - Prometheus specific annotations, these are configured through `prometheus_*` in input values.
  - Previous hardcoded defaults moved to values.yaml.
  - Added unit tests for pod annotations functionality.
  - Bumped chart version from 3.0.6 to 3.0.7.