### PR TITLE
New feature: dsb-nginx-frontend: Pod annotations

### DIFF
--- a/charts/dsb-nginx-frontend/Chart.yaml
+++ b/charts/dsb-nginx-frontend/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.4
+version: 2.0.5

--- a/charts/dsb-nginx-frontend/templates/deployment.yaml
+++ b/charts/dsb-nginx-frontend/templates/deployment.yaml
@@ -19,14 +19,25 @@ spec:
       labels:
         app: {{ .Values.resourceName }}
       annotations:
-        "apparmor.security.beta.kubernetes.io/pod": "runtime/default"
-        # We change this annotation on change in chart or parameters, to force re-create of pods (to pick up config changes etc)
-        # We create a string based on the chart version, and the resolved configuration values.
-        # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum: "chart-version={{ .Chart.Version }}_config-hash={{ .Values | toString | sha256sum }}"
-        co.elastic.logs/json.keys_under_root: "true"
-        co.elastic.logs/json.overwrite_keys: "true"
-        co.elastic.logs/json.add_error_key: "true"
+        {{- /*
+        protected pod annotations:
+          checksum: Required for proper pod creation, see below
+        Additional can be added with:
+          {{- $_ := set $protectedAnnotations "my.custom/annotation"  .Values.myCustomAnnotation }}
+        */}}
+        {{- $protectedAnnotations := dict   "checksum"              (print "chart-version=" .Chart.Version "_config-hash=" (.Values | toString | sha256sum) ) }}
+        {{- /*
+        Final pod annotations are the result of proteced merged with overrides, where protected takes precedence */}}
+        {{- $podAnnotations := .Values.podAnnotations }} {{- /* <-- Required to define as variable to support 'podAnnotations: null' */}}
+        {{- $merged := mustMergeOverwrite $podAnnotations $protectedAnnotations }}
+        {{- range $key, $val := $merged }}
+        {{- if $key | eq "checksum" }}
+        # checksum anntotation:
+        #   We change this annotation on change in chart or parameters, to force re-create of pods (to pick up config changes etc)
+        #   We create a string based on the chart version, and the resolved configuration values.
+        #   See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments{{- end }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
     spec:
       nodeSelector:
         NodePool: workers

--- a/charts/dsb-nginx-frontend/templates/deployment.yaml
+++ b/charts/dsb-nginx-frontend/templates/deployment.yaml
@@ -95,3 +95,6 @@ spec:
             allowPrivilegeEscalation: false
             # Enabling this requires some testing, as nginx writes to /etc/nginx, /var/cache, /tmp etc.
             readOnlyRootFilesystem: false
+            # 101 maps to nginx user and nginx group in the nginx image
+            runAsUser: 101
+            runAsGroup: 101

--- a/charts/dsb-nginx-frontend/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-nginx-frontend/tests/__snapshot__/rendering_test.yaml.snap
@@ -78,6 +78,8 @@ Full manifest should match snapshot:
                 - ALL
               privileged: false
               readOnlyRootFilesystem: false
+              runAsGroup: 101
+              runAsUser: 101
           nodeSelector:
             NodePool: workers
   3: |
@@ -185,6 +187,8 @@ Minimal manifest should match snapshot:
                 - ALL
               privileged: false
               readOnlyRootFilesystem: false
+              runAsGroup: 101
+              runAsUser: 101
           nodeSelector:
             NodePool: workers
   2: |

--- a/charts/dsb-nginx-frontend/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-nginx-frontend/tests/__snapshot__/rendering_test.yaml.snap
@@ -26,10 +26,8 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=2.0.4_config-hash=c4b6757985b404fb0551b430d1199996c349e517ba28dce0b372219f50805ebf
-            co.elastic.logs/json.add_error_key: "true"
-            co.elastic.logs/json.keys_under_root: "true"
-            co.elastic.logs/json.overwrite_keys: "true"
+            checksum: chart-version=2.0.5_config-hash=8c0ab190d9bcdfca21516003152d94d31e8f1c27d4937c485c0a052a04a98415
+            no.dsb-norge.filebeat/autodiscover-template: nginx
           labels:
             app: frontend1
         spec:
@@ -116,7 +114,7 @@ Full manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-nginx-frontend
-        chart-version: 2.0.4
+        chart-version: 2.0.5
       name: frontend1
       namespace: NAMESPACE
     spec:
@@ -141,10 +139,8 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=2.0.4_config-hash=a432b22bbcc05d8e0e524a04eef32797b8e727a21ab3aa43dc1cf46bb00e84a7
-            co.elastic.logs/json.add_error_key: "true"
-            co.elastic.logs/json.keys_under_root: "true"
-            co.elastic.logs/json.overwrite_keys: "true"
+            checksum: chart-version=2.0.5_config-hash=a0b18f85dda3691f8a604c9c8da969a3d041e9021dd3a9042cf3e0ffdca6ad05
+            no.dsb-norge.filebeat/autodiscover-template: nginx
           labels:
             app: frontend
         spec:
@@ -207,7 +203,7 @@ Minimal manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-nginx-frontend
-        chart-version: 2.0.4
+        chart-version: 2.0.5
       name: frontend
       namespace: NAMESPACE
     spec:

--- a/charts/dsb-nginx-frontend/tests/pod_annotations_test.yaml
+++ b/charts/dsb-nginx-frontend/tests/pod_annotations_test.yaml
@@ -1,0 +1,49 @@
+suite: test pod annotations
+templates:
+  - deployment.yaml
+tests:
+  - it: should support custom pod annotations
+    set:
+      podAnnotations:
+        custom-key: custom value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.[custom-key]
+          value: custom value
+  - it: should support overriding default pod annotations
+    set:
+      podAnnotations:
+        no.dsb-norge.filebeat/autodiscover-template: "some template"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.[no.dsb-norge.filebeat/autodiscover-template]
+          value: "some template"
+  - it: should support removing default pod annotations
+    set:
+      podAnnotations:
+        no.dsb-norge.filebeat/autodiscover-template: null
+    asserts:
+      - isNull:
+          path: spec.template.metadata.annotations.[no.dsb-norge.filebeat/autodiscover-template]
+  - it: should support removing all default pod annotations
+    set:
+      podAnnotations: null
+    asserts:
+      - isNull:
+          path: spec.template.metadata.annotations.[apparmor.security.beta.kubernetes.io/pod]
+      - isNull:
+          path: spec.template.metadata.annotations.[no.dsb-norge.filebeat/autodiscover-template]
+  - it: should not overwrite protected pod annotations
+    set:
+      podAnnotations:
+        checksum: "custom value"
+    asserts:
+      - notEqual:
+          path: spec.template.metadata.annotations.checksum
+          value: "custom value"
+  - it: should not remove protected pod annotations
+    set:
+      podAnnotations: null
+    asserts:
+      - isNotNull:
+          path: spec.template.metadata.annotations.checksum

--- a/charts/dsb-nginx-frontend/values.yaml
+++ b/charts/dsb-nginx-frontend/values.yaml
@@ -17,6 +17,17 @@ tag:
 # Annotations to put on the Deployment:
 deploymentAnnotations: {}
 
+# Annotations to put on every pod:
+# Usage when applying with values.yaml
+# podAnnotations:
+#   my-custom-key: "my custom value"                  # add custom annotation
+#   co.elastic.logs/json.message_key: "my_override"   # override a default
+# To remove all defaults and not specify any annotations:
+# podAnnotations: null                                # Note that using empty map {} will not work
+podAnnotations:
+  apparmor.security.beta.kubernetes.io/pod: "runtime/default"
+  no.dsb-norge.filebeat/autodiscover-template: "nginx"
+
 # It is possible to use a normal yaml tree here, for example:
 # root:
 #   node1: 1

--- a/charts/dsb-nginx-frontend/values.yaml
+++ b/charts/dsb-nginx-frontend/values.yaml
@@ -1,17 +1,21 @@
 ---
 # Number of pods to create:
 replicas: 2
+
 # For the pod disruption budget, default is (replicas - 1):
 minAvailableReplicas:
 
-# name to use in kubernetes resources, must be unique inside a namespace
+# Name to use in kubernetes resources, must be unique inside a namespace
 resourceName: frontend
 
+# Container image ref for pods
 image:
+
+# Container image tag for pods
 tag:
 
 # Annotations to put on the Deployment:
-deploymentAnnotations: []
+deploymentAnnotations: {}
 
 # It is possible to use a normal yaml tree here, for example:
 # root:
@@ -22,10 +26,10 @@ deploymentAnnotations: []
 config:
 
 # Reference secrets that are mounted on the pod:
-secretRefs: []
+secretRefs: {}
 
 # Reference configMaps that are mounted on the pod:
-configMapRefs: []
+configMapRefs: {}
 
 # Hostname must be provided if Ingress should be enabled.
 ingress_host:


### PR DESCRIPTION
# New features
- dsb-nginx-frontend: pod annotations: 
  - Pod annotations are now dynamic and configurable via input values.
  - Supports adding custom annotations, overriding default annotation(s) and removing default annotation(s).
  - Some annotations are considered protected and are thus not removable/overwriteable. This is to ensure core functionality of the chart. Currently the only protected annotation is:
    - The `checksum` annotation, ensures proper pod (re-)creation.
  - Previous hardcoded default `apparmor.security.beta.kubernetes.io/pod` moved to values.yaml.
  - Previous hardcoded filebeat defaults removed as we are moving away from json logging for nginx workloads.
  - Added new default pod annotation `no.dsb-norge.filebeat/autodiscover-template`. This will instruct filebeat to apply its nginx template for parsing and shipping nginx logs.
  - Added unit tests for pod annotations functionality.
  - Bumped chart version from 2.0.4 to 2.0.5.

# Fixes
- dsb-nginx-frontend: empty map/dictionary syntax: 
  - yaml nodes that are default empty and assued to be defined as map/dictionaries in the template should also be initialized as map/dictionaries. Not empty arrays. Achieved using yaml flow mapping.