### PR TITLE
Improvement: Tune default CPU allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,33 @@
 
 Create a new release by committing a new version in `charts/*/Chart.yaml`.
 
-Update the test snapshots on Linux with:
+## Unit tests
 
-    docker run -it --rm --name unittest --volume "$(pwd)":/apps quintush/helm-unittest --helm3 --update-snapshot charts/* 
+### Run unit tests
+```bash
+docker run --pull always -it --rm --name unittest --volume "$(pwd)":/apps quintush/helm-unittest --helm3 charts/*
+```
+
+### Update the test snapshots
+```bash
+docker run --pull always -it --rm --name unittest --volume "$(pwd)":/apps quintush/helm-unittest --helm3 --update-snapshot charts/*
+```
 
 ## DSB Spring Boot Chart
 
 To debug locally (requires a kubeconfig setup to a live cluster):
 
     helm upgrade --install --debug --dry-run -f example.yaml test-application dsb-spring-boot
-    
+
 The file `example.yaml` could be like this:
 
     ---
     replicas: 2
-    
+
     image: "dsbacr.azurecr.io/dsb-norge/test-application"
     tag: "latest"
-    
-    application_traefik_rule: "Host(`dev-api.eksplosiver.no`) && PathPrefix(`/test`)" 
+
+    application_traefik_rule: "Host(`dev-api.eksplosiver.no`) && PathPrefix(`/test`)"
 
 To actually deploy, omit the --dry-run flag.
 

--- a/charts/dsb-nginx-frontend/Chart.yaml
+++ b/charts/dsb-nginx-frontend/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.6
+version: 2.0.7

--- a/charts/dsb-nginx-frontend/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-nginx-frontend/tests/__snapshot__/rendering_test.yaml.snap
@@ -26,7 +26,7 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=2.0.6_config-hash=419e82c73dd5a215e4a49d45a23be270a507a28c5a46c0e595fedc7a64eaf19c
+            checksum: chart-version=2.0.7_config-hash=419e82c73dd5a215e4a49d45a23be270a507a28c5a46c0e595fedc7a64eaf19c
             no.dsb-norge.filebeat/autodiscover-template: nginx
           labels:
             app: frontend1
@@ -116,7 +116,7 @@ Full manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-nginx-frontend
-        chart-version: 2.0.6
+        chart-version: 2.0.7
       name: frontend1
       namespace: NAMESPACE
     spec:
@@ -141,7 +141,7 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=2.0.6_config-hash=a0b18f85dda3691f8a604c9c8da969a3d041e9021dd3a9042cf3e0ffdca6ad05
+            checksum: chart-version=2.0.7_config-hash=d0f34ba4599695c68d8bd6039e0f7475494117f879737db76397bdcd7f0c0b4d
             no.dsb-norge.filebeat/autodiscover-template: nginx
           labels:
             app: frontend
@@ -175,10 +175,10 @@ Minimal manifest should match snapshot:
               initialDelaySeconds: 2
             resources:
               limits:
-                cpu: 0.8
+                cpu: 100m
                 memory: 256Mi
               requests:
-                cpu: 0.2
+                cpu: 50m
                 memory: 128Mi
             securityContext:
               allowPrivilegeEscalation: false
@@ -207,7 +207,7 @@ Minimal manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-nginx-frontend
-        chart-version: 2.0.6
+        chart-version: 2.0.7
       name: frontend
       namespace: NAMESPACE
     spec:

--- a/charts/dsb-nginx-frontend/values.yaml
+++ b/charts/dsb-nginx-frontend/values.yaml
@@ -52,5 +52,5 @@ port: 8080
 memory_request: "128Mi"
 memory_limit: "256Mi"
 
-cpu_request: "0.2"
-cpu_limit: "0.8"
+cpu_request: "50m"
+cpu_limit: "100m"

--- a/charts/dsb-spring-boot-job/Chart.yaml
+++ b/charts/dsb-spring-boot-job/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.6
+version: 2.0.7

--- a/charts/dsb-spring-boot-job/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot-job/tests/__snapshot__/rendering_test.yaml.snap
@@ -30,7 +30,7 @@ Full manifest should match snapshot:
             metadata:
               annotations:
                 apparmor.security.beta.kubernetes.io/pod: runtime/default
-                checksum: chart-version=2.0.6_config-hash=9ce8ae231891db9bc63c4cae273adbed21f7800c566a6dfaec7cddc5fea302a9
+                checksum: chart-version=2.0.7_config-hash=9ce8ae231891db9bc63c4cae273adbed21f7800c566a6dfaec7cddc5fea302a9
                 co.elastic.logs/json.add_error_key: "true"
                 co.elastic.logs/json.keys_under_root: "true"
                 co.elastic.logs/json.overwrite_keys: "true"
@@ -100,7 +100,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=2.0.6_config-hash=9ce8ae231891db9bc63c4cae273adbed21f7800c566a6dfaec7cddc5fea302a9
+            checksum: chart-version=2.0.7_config-hash=9ce8ae231891db9bc63c4cae273adbed21f7800c566a6dfaec7cddc5fea302a9
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -157,7 +157,7 @@ Minimal manifest should match snapshot:
             metadata:
               annotations:
                 apparmor.security.beta.kubernetes.io/pod: runtime/default
-                checksum: chart-version=2.0.6_config-hash=f15538db5d9d938e85141d4a8db9d69c8a129e36700fa3b50532b8828dcafd7b
+                checksum: chart-version=2.0.7_config-hash=aa6e568e9635eb3ae58a00c11520e5e1d7e373b3d6faeb117962f22713fae031
                 co.elastic.logs/json.add_error_key: "true"
                 co.elastic.logs/json.keys_under_root: "true"
                 co.elastic.logs/json.overwrite_keys: "true"
@@ -176,7 +176,7 @@ Minimal manifest should match snapshot:
                     cpu: 2.5
                     memory: 1024Mi
                   requests:
-                    cpu: 0.2
+                    cpu: 100m
                     memory: 256Mi
                 securityContext:
                   allowPrivilegeEscalation: false

--- a/charts/dsb-spring-boot-job/values.yaml
+++ b/charts/dsb-spring-boot-job/values.yaml
@@ -31,7 +31,7 @@ configMapRefs: []
 memory_request: "256Mi"
 memory_limit: "1024Mi"
 
-cpu_request: "0.2"
+cpu_request: "100m"
 cpu_limit: "2.5"
 
 # If this is enabled, a docker image with a mssql database is created.

--- a/charts/dsb-spring-boot/Chart.yaml
+++ b/charts/dsb-spring-boot/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.10
+version: 3.0.11

--- a/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
@@ -86,7 +86,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=3.0.9_config-hash=fd0821a4e635e9a57e385c8567ff240e6cccfcd3198c6fc54541b80af752b38e
+            checksum: chart-version=3.0.11_config-hash=da0765ce35ba581382bb4892b4c5faeda09da35eb66243159c4388f57367b2d8
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -141,7 +141,7 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=3.0.9_config-hash=3998baf6ea162972197d9a0292a7487cbfc82dea0bc555f8e25e446d8337feee
+            checksum: chart-version=3.0.11_config-hash=3998baf6ea162972197d9a0292a7487cbfc82dea0bc555f8e25e446d8337feee
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -278,7 +278,7 @@ Full manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-spring-boot
-        chart-version: 3.0.9
+        chart-version: 3.0.11
         management.port: "81"
         spring-boot: "true"
       name: RELEASE-NAME
@@ -340,7 +340,7 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=3.0.9_config-hash=0374a9c012639d81734c1e98ecf42405bbd8a9b13acd5fb96d483e7c85ede482
+            checksum: chart-version=3.0.11_config-hash=f7d6bf8b36fa4f200cb1ae9b353da8494a2ac2c2ec6ba004694a58706bbc64fd
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -398,7 +398,7 @@ Minimal manifest should match snapshot:
                 cpu: 2.5
                 memory: 1024Mi
               requests:
-                cpu: 0.2
+                cpu: 100m
                 memory: 256Mi
             securityContext:
               allowPrivilegeEscalation: false
@@ -435,7 +435,7 @@ Minimal manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-spring-boot
-        chart-version: 3.0.9
+        chart-version: 3.0.11
         management.port: "8180"
         spring-boot: "true"
       name: RELEASE-NAME

--- a/charts/dsb-spring-boot/values.yaml
+++ b/charts/dsb-spring-boot/values.yaml
@@ -64,7 +64,7 @@ prometheus_path: "/actuator/prometheus"
 memory_request: "256Mi"
 memory_limit: "1024Mi"
 
-cpu_request: "0.2"
+cpu_request: "100m"
 cpu_limit: "2.5"
 
 # If this is enabled, a docker image with a mssql database is created.


### PR DESCRIPTION
# Improvements
- dsb-spring-boot:
  - Reserve less CPU by default for spring apps.
- dsb-nginx-frontend:
  - Reserve less CPU by default, also set max limit lower for nginx apps.