### PR TITLE
Improvement: Optional PodDisruptionBudget

### DIFF
--- a/charts/dsb-nginx-frontend/Chart.yaml
+++ b/charts/dsb-nginx-frontend/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.7
+version: 2.0.8

--- a/charts/dsb-nginx-frontend/templates/pod-disruption-budget.yaml
+++ b/charts/dsb-nginx-frontend/templates/pod-disruption-budget.yaml
@@ -1,3 +1,4 @@
+{{- if (not (eq (toString .Values.createPodDisruptionBudget) "false")) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -7,3 +8,4 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.resourceName }}
+{{- end }}

--- a/charts/dsb-nginx-frontend/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-nginx-frontend/tests/__snapshot__/rendering_test.yaml.snap
@@ -26,7 +26,7 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=2.0.7_config-hash=419e82c73dd5a215e4a49d45a23be270a507a28c5a46c0e595fedc7a64eaf19c
+            checksum: chart-version=2.0.8_config-hash=c4d93ec75302ddbd7e73f728a9c4fc66b1feb99506d53d8f98f3663894db34c1
             no.dsb-norge.filebeat/autodiscover-template: nginx
           labels:
             app: frontend1
@@ -116,7 +116,7 @@ Full manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-nginx-frontend
-        chart-version: 2.0.7
+        chart-version: 2.0.8
       name: frontend1
       namespace: NAMESPACE
     spec:
@@ -141,7 +141,7 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=2.0.7_config-hash=d0f34ba4599695c68d8bd6039e0f7475494117f879737db76397bdcd7f0c0b4d
+            checksum: chart-version=2.0.8_config-hash=ae9da9c9fb9bc9b0be2beed048e1400c0d1d991770082a0687f7a23d425d4386
             no.dsb-norge.filebeat/autodiscover-template: nginx
           labels:
             app: frontend
@@ -207,7 +207,7 @@ Minimal manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-nginx-frontend
-        chart-version: 2.0.7
+        chart-version: 2.0.8
       name: frontend
       namespace: NAMESPACE
     spec:
@@ -216,3 +216,14 @@ Minimal manifest should match snapshot:
         port: 8080
       selector:
         app: frontend
+should render default with PodDisruptionBudget and should match snapshot:
+  1: |
+    apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      name: frontend
+    spec:
+      minAvailable: 1
+      selector:
+        matchLabels:
+          app: frontend

--- a/charts/dsb-nginx-frontend/tests/rendering_test.yaml
+++ b/charts/dsb-nginx-frontend/tests/rendering_test.yaml
@@ -10,7 +10,21 @@ tests:
       tag: latest
     asserts:
       - matchSnapshot: { }
-
+  - it: should render default with PodDisruptionBudget and should match snapshot
+    templates:
+      - pod-disruption-budget.yaml
+    asserts:
+      - matchSnapshot: { }
+      - isKind:
+          of: PodDisruptionBudget
+  - it: should be possible to render without PodDisruptionBudget
+    templates:
+      - pod-disruption-budget.yaml
+    set:
+      createPodDisruptionBudget: false
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: Full manifest should match snapshot
     templates:
       - config-map.yaml

--- a/charts/dsb-nginx-frontend/values.yaml
+++ b/charts/dsb-nginx-frontend/values.yaml
@@ -5,6 +5,9 @@ replicas: 2
 # For the pod disruption budget, default is (replicas - 1):
 minAvailableReplicas:
 
+# Set to false to avoid creating PodDisruptionBudget for pods
+createPodDisruptionBudget: "true"
+
 # Name to use in kubernetes resources, must be unique inside a namespace
 resourceName: frontend
 

--- a/charts/dsb-spring-boot/Chart.yaml
+++ b/charts/dsb-spring-boot/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.11
+version: 3.0.12

--- a/charts/dsb-spring-boot/templates/podDisruptionBudget.yaml
+++ b/charts/dsb-spring-boot/templates/podDisruptionBudget.yaml
@@ -1,3 +1,4 @@
+{{- if (not (eq (toString .Values.createPodDisruptionBudget) "false")) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -7,3 +8,4 @@ spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}-app
+{{- end }}

--- a/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
@@ -86,7 +86,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=3.0.11_config-hash=da0765ce35ba581382bb4892b4c5faeda09da35eb66243159c4388f57367b2d8
+            checksum: chart-version=3.0.12_config-hash=68c201fff6f8e6524da6b0a5cd7c11d2c6641802e21fd9a2e0383116f83d627a
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -141,7 +141,7 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=3.0.11_config-hash=3998baf6ea162972197d9a0292a7487cbfc82dea0bc555f8e25e446d8337feee
+            checksum: chart-version=3.0.12_config-hash=8e7ca25741546892b84ec236a47d652934bcc7659c580001a6e2ef70131b1d38
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -278,7 +278,7 @@ Full manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-spring-boot
-        chart-version: 3.0.11
+        chart-version: 3.0.12
         management.port: "81"
         spring-boot: "true"
       name: RELEASE-NAME
@@ -340,7 +340,7 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=3.0.11_config-hash=f7d6bf8b36fa4f200cb1ae9b353da8494a2ac2c2ec6ba004694a58706bbc64fd
+            checksum: chart-version=3.0.12_config-hash=36b246a9aaf6300ea3861c32e182c90bf903ec03c3f003db10fe49a9d86916bb
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -435,7 +435,7 @@ Minimal manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-spring-boot
-        chart-version: 3.0.11
+        chart-version: 3.0.12
         management.port: "8180"
         spring-boot: "true"
       name: RELEASE-NAME
@@ -454,3 +454,14 @@ Minimal manifest should match snapshot:
         app: RELEASE-NAME-app
       name: RELEASE-NAME-service-account
       namespace: NAMESPACE
+should render default with PodDisruptionBudget and should match snapshot:
+  1: |
+    apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      name: RELEASE-NAME.pdb
+    spec:
+      minAvailable: 1
+      selector:
+        matchLabels:
+          app: RELEASE-NAME-app

--- a/charts/dsb-spring-boot/tests/rendering_test.yaml
+++ b/charts/dsb-spring-boot/tests/rendering_test.yaml
@@ -11,6 +11,21 @@ tests:
       tag: latest
     asserts:
       - matchSnapshot: { }
+  - it: should render default with PodDisruptionBudget and should match snapshot
+    templates:
+      - podDisruptionBudget.yaml
+    asserts:
+      - matchSnapshot: { }
+      - isKind:
+          of: PodDisruptionBudget
+  - it: should be possible to render without PodDisruptionBudget
+    templates:
+      - podDisruptionBudget.yaml
+    set:
+      createPodDisruptionBudget: false
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: Full manifest should match snapshot
     templates:
       - configMap.yaml

--- a/charts/dsb-spring-boot/values.yaml
+++ b/charts/dsb-spring-boot/values.yaml
@@ -5,6 +5,9 @@ replicas: 2
 # For the pod disruption budget, default is (replicas - 1):
 minAvailableReplicas:
 
+# Set to false to avoid creating PodDisruptionBudget for pods
+createPodDisruptionBudget: true
+
 # Container image ref for pods
 image:
 


### PR DESCRIPTION
# Improvements
- Improvement: Make creating PodDisruptionBudget optional and default enabled. Applies to the following charts:
  - dsb-nginx-frontend
  - dsb-spring-boot