### PR TITLE
New database container image

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Load custom test application image
         run: |
           az acr login --name dsbacr --username ${{ secrets.AZ_CR_USER }} --password ${{ secrets.AZ_CR_SECRET }}
-          docker pull dsbacr.azurecr.io/dsb-norge/test-application:2021.06.03.69273
-          kind load --name chart-testing docker-image dsbacr.azurecr.io/dsb-norge/test-application:2021.06.03.69273
+          docker pull dsbacr.azurecr.io/dsb-norge/test-application:latest
+          kind load --name chart-testing docker-image dsbacr.azurecr.io/dsb-norge/test-application:latest
 
       - name: Run chart-testing (install)
         run: ct install --all

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Run Helm Unittests
         run: docker run --rm --name unittest --volume "$(pwd)":/apps quintush/helm-unittest --helm3 charts/*
 
+      - name: log into azure container registry (ACR)
+        uses: azure/docker-login@v1
+        with:
+          login-server: dsbacr.azurecr.io
+          username: ${{ secrets.AZ_CR_USER }}
+          password: ${{ secrets.AZ_CR_SECRET }}
+
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
@@ -44,7 +51,6 @@ jobs:
 
       - name: Load custom test application image
         run: |
-          az acr login --name dsbacr --username ${{ secrets.AZ_CR_USER }} --password ${{ secrets.AZ_CR_SECRET }}
           docker pull dsbacr.azurecr.io/dsb-norge/test-application:latest
           kind load --name chart-testing docker-image dsbacr.azurecr.io/dsb-norge/test-application:latest
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.6.3
+          version: v3.7.2
 
-      - name: Run linting
+      - name: Run linting (helm)
         run: helm lint charts/*
 
       - name: Run Helm Unittests
@@ -40,7 +40,10 @@ jobs:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
+        uses: helm/chart-testing-action@v2.2.0
+
+      - name: Run linting (ct)
+        run: ct lint --all
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
@@ -51,6 +54,9 @@ jobs:
 
       - name: Load custom test application image
         run: |
+          # Make image(s) available to kind cluster as it has no pullSecrets
+          # K8s defaults to always pull if tag is "latest", this is prevented by having
+          # 'imagePullPolicy: "Never"' in charts/*/ci/*-values.yaml
           docker pull dsbacr.azurecr.io/dsb-norge/test-application:latest
           kind load --name chart-testing docker-image dsbacr.azurecr.io/dsb-norge/test-application:latest
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -43,7 +43,7 @@ jobs:
         uses: helm/chart-testing-action@v2.2.0
 
       - name: Run linting (ct)
-        run: ct lint --all
+        run: ct lint --all --validate-maintainers=false
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Create a new release by committing a new version in `charts/*/Chart.yaml`.
 
+## Linting
+```bash
+# Helm
+helm lint charts/*
+
+# Chart-testing
+docker run --pull always -it --rm --name unittest --volume "$(pwd)":"$(pwd)" --workdir "$(pwd)" quay.io/helmpack/chart-testing ct lint --all --validate-maintainers=false
+```
+
 ## Unit tests
 
 ### Run unit tests

--- a/charts/dsb-spring-boot-job/Chart.yaml
+++ b/charts/dsb-spring-boot-job/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.7
+version: 2.0.8

--- a/charts/dsb-spring-boot-job/ci/test-application-values.yaml
+++ b/charts/dsb-spring-boot-job/ci/test-application-values.yaml
@@ -2,6 +2,11 @@
 image: "dsbacr.azurecr.io/dsb-norge/test-application"
 tag: "latest"
 
+# Kind cluster should not attempt to pull as it's missing docker credentials
+# The Kubernetes default pull policy is IfNotPresent unless the image tag is :latest
+# or omitted (and implicitly :latest) in which case the default policy is Always.
+imagePullPolicy: "Never"
+
 springProfiles: "kubernetes,runner"
 
 schedule: "*/1 * * * *"

--- a/charts/dsb-spring-boot-job/ci/test-application-values.yaml
+++ b/charts/dsb-spring-boot-job/ci/test-application-values.yaml
@@ -1,6 +1,6 @@
 ---
 image: "dsbacr.azurecr.io/dsb-norge/test-application"
-tag: "2021.06.03.69273"
+tag: "latest"
 
 springProfiles: "kubernetes,runner"
 

--- a/charts/dsb-spring-boot-job/templates/cronJob.yaml
+++ b/charts/dsb-spring-boot-job/templates/cronJob.yaml
@@ -40,6 +40,9 @@ spec:
             NodePool: workers
           containers:
             - image: "{{ .Values.image }}:{{ .Values.tag }}"
+              {{- if .Values.imagePullPolicy }}
+              imagePullPolicy: {{ .Values.imagePullPolicy }}
+              {{- end }}
               name: {{ .Release.Name }}-job
               resources:
                 requests:

--- a/charts/dsb-spring-boot-job/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot-job/tests/__snapshot__/rendering_test.yaml.snap
@@ -30,7 +30,7 @@ Full manifest should match snapshot:
             metadata:
               annotations:
                 apparmor.security.beta.kubernetes.io/pod: runtime/default
-                checksum: chart-version=2.0.7_config-hash=9ce8ae231891db9bc63c4cae273adbed21f7800c566a6dfaec7cddc5fea302a9
+                checksum: chart-version=2.0.8_config-hash=9ce8ae231891db9bc63c4cae273adbed21f7800c566a6dfaec7cddc5fea302a9
                 co.elastic.logs/json.add_error_key: "true"
                 co.elastic.logs/json.keys_under_root: "true"
                 co.elastic.logs/json.overwrite_keys: "true"
@@ -100,7 +100,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=2.0.7_config-hash=9ce8ae231891db9bc63c4cae273adbed21f7800c566a6dfaec7cddc5fea302a9
+            checksum: chart-version=2.0.8_config-hash=9ce8ae231891db9bc63c4cae273adbed21f7800c566a6dfaec7cddc5fea302a9
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -157,7 +157,7 @@ Minimal manifest should match snapshot:
             metadata:
               annotations:
                 apparmor.security.beta.kubernetes.io/pod: runtime/default
-                checksum: chart-version=2.0.7_config-hash=aa6e568e9635eb3ae58a00c11520e5e1d7e373b3d6faeb117962f22713fae031
+                checksum: chart-version=2.0.8_config-hash=ec476571dcb6cda970c57fa1705dd3c1095cedc7cadbe12679ce907d4579b6be
                 co.elastic.logs/json.add_error_key: "true"
                 co.elastic.logs/json.keys_under_root: "true"
                 co.elastic.logs/json.overwrite_keys: "true"

--- a/charts/dsb-spring-boot-job/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot-job/tests/__snapshot__/rendering_test.yaml.snap
@@ -30,7 +30,7 @@ Full manifest should match snapshot:
             metadata:
               annotations:
                 apparmor.security.beta.kubernetes.io/pod: runtime/default
-                checksum: chart-version=2.0.8_config-hash=9ce8ae231891db9bc63c4cae273adbed21f7800c566a6dfaec7cddc5fea302a9
+                checksum: chart-version=2.0.8_config-hash=4080e972a3fe33fd94f804f4d0fe2b795bc5e714808b95e1b0441d4fd74b794b
                 co.elastic.logs/json.add_error_key: "true"
                 co.elastic.logs/json.keys_under_root: "true"
                 co.elastic.logs/json.overwrite_keys: "true"
@@ -57,6 +57,7 @@ Full manifest should match snapshot:
                 - configMapRef:
                     name: RELEASE-NAME-configmap
                 image: wordpress:greatest
+                imagePullPolicy: customValue
                 name: RELEASE-NAME-job
                 resources:
                   limits:
@@ -100,7 +101,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=2.0.8_config-hash=9ce8ae231891db9bc63c4cae273adbed21f7800c566a6dfaec7cddc5fea302a9
+            checksum: chart-version=2.0.8_config-hash=4080e972a3fe33fd94f804f4d0fe2b795bc5e714808b95e1b0441d4fd74b794b
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -157,7 +158,7 @@ Minimal manifest should match snapshot:
             metadata:
               annotations:
                 apparmor.security.beta.kubernetes.io/pod: runtime/default
-                checksum: chart-version=2.0.8_config-hash=ec476571dcb6cda970c57fa1705dd3c1095cedc7cadbe12679ce907d4579b6be
+                checksum: chart-version=2.0.8_config-hash=8c6f800ce930ade2bdf449ee3292d43ab0370412c113c0cc4645e1386845d2ac
                 co.elastic.logs/json.add_error_key: "true"
                 co.elastic.logs/json.keys_under_root: "true"
                 co.elastic.logs/json.overwrite_keys: "true"

--- a/charts/dsb-spring-boot-job/tests/rendering_test.yaml
+++ b/charts/dsb-spring-boot-job/tests/rendering_test.yaml
@@ -20,6 +20,7 @@ tests:
       minAvailableReplicas: 1
       image: wordpress
       tag: greatest
+      imagePullPolicy: customValue
       cronJobAnnotations:
         key1: value1
         key2: value2

--- a/charts/dsb-spring-boot-job/values.yaml
+++ b/charts/dsb-spring-boot-job/values.yaml
@@ -1,6 +1,12 @@
 ---
+# Container image ref for cron job
 image:
+
+# Container image tag for cron job
 tag:
+
+# Possibility to override default imagePullPolicy
+imagePullPolicy:
 
 # Annotations to put on the CronJob:
 cronJobAnnotations: []

--- a/charts/dsb-spring-boot-job/values.yaml
+++ b/charts/dsb-spring-boot-job/values.yaml
@@ -38,6 +38,6 @@ cpu_limit: "2.5"
 # The following env variables are then added to the pod:
 # DATABASE_CONTAINER_USER, DATABASE_CONTAINER_PASSWORD, DATABASE_CONTAINER_HOST_AND_PORT and DATABASE_CONTAINER_DATABASE
 database_container_enabled: false
-database_container_image: "dsbacr.azurecr.io/dsb-norge/mssql-empty:latest"
+database_container_image: "dsbacr.azurecr.io/dsb-norge/dsb-mssql-server:2019-latest"
 # This is hardcoded in the image used:
 database_container_password: DoN0tUse1Production

--- a/charts/dsb-spring-boot/Chart.yaml
+++ b/charts/dsb-spring-boot/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.12
+version: 3.0.13

--- a/charts/dsb-spring-boot/ci/test-application-values.yaml
+++ b/charts/dsb-spring-boot/ci/test-application-values.yaml
@@ -2,6 +2,6 @@
 replicas: 2
 
 image: "dsbacr.azurecr.io/dsb-norge/test-application"
-tag: "2021.06.03.69273"
+tag: "latest"
 
 ingress_host: "example.com"

--- a/charts/dsb-spring-boot/ci/test-application-values.yaml
+++ b/charts/dsb-spring-boot/ci/test-application-values.yaml
@@ -4,4 +4,9 @@ replicas: 2
 image: "dsbacr.azurecr.io/dsb-norge/test-application"
 tag: "latest"
 
+# Kind cluster should not attempt to pull as it's missing docker credentials
+# The Kubernetes default pull policy is IfNotPresent unless the image tag is :latest
+# or omitted (and implicitly :latest) in which case the default policy is Always.
+imagePullPolicy: "Never"
+
 ingress_host: "example.com"

--- a/charts/dsb-spring-boot/templates/deployment.yaml
+++ b/charts/dsb-spring-boot/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
       containers:
         - name: {{ .Release.Name }}-container
           image: "{{ .Values.image }}:{{ .Values.tag }}"
+          {{- if .Values.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- end }}
           # Sleep before shutdown to finish requests, as suggested here:
           # https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#cloud-deployment-kubernetes
           lifecycle:

--- a/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
@@ -86,7 +86,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=3.0.12_config-hash=68c201fff6f8e6524da6b0a5cd7c11d2c6641802e21fd9a2e0383116f83d627a
+            checksum: chart-version=3.0.13_config-hash=59fbe5ba43f4a185c346e42e668c9d29efd997d1f58869e6d1bea82a7ca58d89
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -141,7 +141,7 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=3.0.12_config-hash=8e7ca25741546892b84ec236a47d652934bcc7659c580001a6e2ef70131b1d38
+            checksum: chart-version=3.0.13_config-hash=8e7ca25741546892b84ec236a47d652934bcc7659c580001a6e2ef70131b1d38
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -278,7 +278,7 @@ Full manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-spring-boot
-        chart-version: 3.0.12
+        chart-version: 3.0.13
         management.port: "81"
         spring-boot: "true"
       name: RELEASE-NAME
@@ -340,7 +340,7 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=3.0.12_config-hash=36b246a9aaf6300ea3861c32e182c90bf903ec03c3f003db10fe49a9d86916bb
+            checksum: chart-version=3.0.13_config-hash=eaf5ddb4c8ce0087f4decd9260c02d64e5acf53b405c5ca349d2be90bd7b1707
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -435,7 +435,7 @@ Minimal manifest should match snapshot:
     metadata:
       labels:
         chart-name: dsb-spring-boot
-        chart-version: 3.0.12
+        chart-version: 3.0.13
         management.port: "8180"
         spring-boot: "true"
       name: RELEASE-NAME

--- a/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
@@ -86,7 +86,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=3.0.13_config-hash=59fbe5ba43f4a185c346e42e668c9d29efd997d1f58869e6d1bea82a7ca58d89
+            checksum: chart-version=3.0.13_config-hash=8f26a2f74068c477b9a12b3e55cc0ff82edb038309bd1d85baf5f5b926df7cb2
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -141,7 +141,7 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=3.0.13_config-hash=8e7ca25741546892b84ec236a47d652934bcc7659c580001a6e2ef70131b1d38
+            checksum: chart-version=3.0.13_config-hash=b1cc2ea5755992a5797695bd9842d4c644fb8c6fcb4c514b9b718b39079b091b
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -185,6 +185,7 @@ Full manifest should match snapshot:
             - configMapRef:
                 name: RELEASE-NAME-configmap
             image: wordpress:greatest
+            imagePullPolicy: customValue
             lifecycle:
               preStop:
                 exec:
@@ -340,7 +341,7 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=3.0.13_config-hash=eaf5ddb4c8ce0087f4decd9260c02d64e5acf53b405c5ca349d2be90bd7b1707
+            checksum: chart-version=3.0.13_config-hash=52c4ba0f5c9056805854f2ad5abb688fbd2cac7c5825003fa50efda502512003
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"

--- a/charts/dsb-spring-boot/tests/rendering_test.yaml
+++ b/charts/dsb-spring-boot/tests/rendering_test.yaml
@@ -43,6 +43,7 @@ tests:
       minAvailableReplicas: 1
       image: wordpress
       tag: greatest
+      imagePullPolicy: customValue
       deploymentAnnotations:
         key1: value1
         key2: value2

--- a/charts/dsb-spring-boot/values.yaml
+++ b/charts/dsb-spring-boot/values.yaml
@@ -14,6 +14,9 @@ image:
 # Container image tag for pods
 tag:
 
+# Possibility to override default imagePullPolicy
+imagePullPolicy:
+
 # Annotations to put on the Deployment:
 deploymentAnnotations: {}
 

--- a/charts/dsb-spring-boot/values.yaml
+++ b/charts/dsb-spring-boot/values.yaml
@@ -74,7 +74,7 @@ cpu_limit: "2.5"
 # The following env variables are then added to the pod:
 # DATABASE_CONTAINER_USER, DATABASE_CONTAINER_PASSWORD, DATABASE_CONTAINER_HOST_AND_PORT and DATABASE_CONTAINER_DATABASE
 database_container_enabled: false
-database_container_image: "dsbacr.azurecr.io/dsb-norge/mssql-empty:latest"
+database_container_image: "dsbacr.azurecr.io/dsb-norge/dsb-mssql-server:2019-latest"
 # This is hardcoded in the image used:
 database_container_password: DoN0tUse1Production
 


### PR DESCRIPTION
# Improvements
- New database container image: Change `dsb-spring-boot` and `dsb-spring-boot-job` to use the new dsb-mssql-server pre-baked image.
- CI: Unpin version of test-application

# Fixes
- Fix: docker auth issue during CI.
- Fix: CI: use latest of test-application: 
  - Kubernetes defaults to always pull if tag is "latest". Kind cluster fails to pull images as it has no `pullSecrets`. We prevent pulling by setting `imagePullPolicy: "Never"` in the CI config.
- Fix: Linting: skip maintainers.

# Chores
- Bump helm version in CI.
- Bump chart-testing-action.
