### PR TITLE
dsb-spring-boot: global override of key vault defaults

### DIFF
--- a/charts/dsb-spring-boot/Chart.yaml
+++ b/charts/dsb-spring-boot/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.0
+version: 4.2.0

--- a/charts/dsb-spring-boot/templates/csi-secrets-store-azure.yaml
+++ b/charts/dsb-spring-boot/templates/csi-secrets-store-azure.yaml
@@ -11,12 +11,15 @@
   {{ fail (printf "ERROR: 'vaults' key is required in .azureKeyVault definition with type 'map'.") }}
 {{- end -}}
 
-{{- if not (kindIs "map" .Values.azureKeyVault.defaultValues ) -}}
+{{- if not (kindIs "map" ( .Values.global.azureKeyVaultDefaultValues | default .Values.azureKeyVault.defaultValues ) ) -}}
   {{ fail (printf "ERROR: 'defaultValues' key is required in .azureKeyVault definition with type 'map'.") }}
 {{- end -}}
 
 {{/* loop over keyvaults */}}
-{{- $vaultsWithDefaultValues := (include "dackvp.vaults-enriched" (list .Values.azureKeyVault.vaults .Values.azureKeyVault.defaultValues .Release.Name) | fromYaml).output -}}
+{{- $vaultsWithDefaultValues := (include "dackvp.vaults-enriched" (list
+  .Values.azureKeyVault.vaults
+  ( .Values.global.azureKeyVaultDefaultValues | default .Values.azureKeyVault.defaultValues )
+  .Release.Name) | fromYaml).output -}}
 {{- range $vaultKey, $vaultDef := $vaultsWithDefaultValues -}}
 
 {{- if (include "dackvp.should-render-secrets-store-provider" (list $vaultKey $vaultDef) ) }}

--- a/charts/dsb-spring-boot/templates/deployment.yaml
+++ b/charts/dsb-spring-boot/templates/deployment.yaml
@@ -154,7 +154,7 @@ spec:
           {{- /* env config from dsb-azure-csi-key-vault-provider */ -}}
           {{- include "dackvp.render-kubernetes-env-config" (list
             .Values.azureKeyVault.vaults
-            .Values.azureKeyVault.defaultValues
+            ( .Values.global.azureKeyVaultDefaultValues | default .Values.azureKeyVault.defaultValues )
             .Release.Name) | indent 12 }}
           ports:
             - containerPort: {{ .Values.application_web_port }}
@@ -177,7 +177,7 @@ spec:
           {{- /* volume mounts from dsb-azure-csi-key-vault-provider */ -}}
           {{- include "dackvp.render-kubernetes-volume-mounts" (list
             .Values.azureKeyVault.vaults
-            .Values.azureKeyVault.defaultValues
+            ( .Values.global.azureKeyVaultDefaultValues | default .Values.azureKeyVault.defaultValues )
             .Release.Name) | indent 12 }}
           securityContext:
             capabilities:
@@ -204,5 +204,5 @@ spec:
       {{- /* volumes from dsb-azure-csi-key-vault-provider */ -}}
       {{- include "dackvp.render-kubernetes-volumes" (list
         .Values.azureKeyVault.vaults
-        .Values.azureKeyVault.defaultValues
+        ( .Values.global.azureKeyVaultDefaultValues | default .Values.azureKeyVault.defaultValues )
         .Release.Name) | indent 8 }}

--- a/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
@@ -22,7 +22,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=4.1.0_config-hash=25bb574790b8c4f1a83c55fca97463112f9d0b8eac2840f5d1864af733b6efd8
+            checksum: chart-version=4.2.0_config-hash=92a40549d0ad5b5b01b301d62056f2b80bd139e726b59d90f9787f4137e46520
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -80,7 +80,7 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=4.1.0_config-hash=d4999089ecfc7f4583a1960dce2d1a58a2331255ad54861ed5ac48986f329416
+            checksum: chart-version=4.2.0_config-hash=70ee77ee1ddebe13a0f9e4e91af4bf085cc0d6e1ff031e2814d67356e6c02bf5
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -92,9 +92,9 @@ Full manifest should match snapshot:
             app.kubernetes.io/name: Rendering test
             app.kubernetes.io/part-of: Verification stuff
             app.kubernetes.io/version: greatest
-            helm.sh/chart: dsb-spring-boot-4.1.0
+            helm.sh/chart: dsb-spring-boot-4.2.0
             helm.sh/chart-name: dsb-spring-boot
-            helm.sh/chart-version: 4.1.0
+            helm.sh/chart-version: 4.2.0
         spec:
           affinity:
             podAntiAffinity:
@@ -295,10 +295,10 @@ Full manifest should match snapshot:
         app.kubernetes.io/part-of: Verification stuff
         app.kubernetes.io/version: greatest
         chart-name: dsb-spring-boot
-        chart-version: 4.1.0
-        helm.sh/chart: dsb-spring-boot-4.1.0
+        chart-version: 4.2.0
+        helm.sh/chart: dsb-spring-boot-4.2.0
         helm.sh/chart-name: dsb-spring-boot
-        helm.sh/chart-version: 4.1.0
+        helm.sh/chart-version: 4.2.0
         management.port: "81"
         spring-boot: "true"
       name: RELEASE-NAME
@@ -501,7 +501,7 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=4.1.0_config-hash=a810c15bea32008a81d1eb477c3910683db48f1db0fd0308b5acb40e3fbecf13
+            checksum: chart-version=4.2.0_config-hash=73d6806c42f5255bab4720db975a591808385b27c7596fe6cc09e34faf84046e
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -513,9 +513,9 @@ Minimal manifest should match snapshot:
             app.kubernetes.io/name: RELEASE-NAME
             app.kubernetes.io/part-of: RELEASE-NAME
             app.kubernetes.io/version: latest
-            helm.sh/chart: dsb-spring-boot-4.1.0
+            helm.sh/chart: dsb-spring-boot-4.2.0
             helm.sh/chart-name: dsb-spring-boot
-            helm.sh/chart-version: 4.1.0
+            helm.sh/chart-version: 4.2.0
         spec:
           affinity:
             podAntiAffinity:
@@ -609,10 +609,10 @@ Minimal manifest should match snapshot:
         app.kubernetes.io/part-of: RELEASE-NAME
         app.kubernetes.io/version: latest
         chart-name: dsb-spring-boot
-        chart-version: 4.1.0
-        helm.sh/chart: dsb-spring-boot-4.1.0
+        chart-version: 4.2.0
+        helm.sh/chart: dsb-spring-boot-4.2.0
         helm.sh/chart-name: dsb-spring-boot
-        helm.sh/chart-version: 4.1.0
+        helm.sh/chart-version: 4.2.0
         management.port: "8180"
         spring-boot: "true"
       name: RELEASE-NAME

--- a/charts/dsb-spring-boot/tests/csi_secrets_store_azure_test.yaml
+++ b/charts/dsb-spring-boot/tests/csi_secrets_store_azure_test.yaml
@@ -46,7 +46,7 @@ tests:
       - equal:
           path: spec.parameters.useVMManagedIdentity
           value: "true"
-  - it: should use values from key vault spec (not default values) if defined
+  - it: should prefer values from key vault spec over default values if defined
     templates:
       - csi-secrets-store-azure.yaml
     set:
@@ -81,6 +81,96 @@ tests:
           tenantId: b2255c28-9e28-4641-a6bc-b63391d59141
           clientId: b2255c28-9e28-4641-a6bc-b63391d59142
           kvName: kv-rg00-ss0-render-dev1
+        vaults:
+          myKv1:
+            secrets:
+              - nameInKv: "name-of-secret-in-vault"
+                fileMountPath: "/hardcoded/path/of/secret/as/file"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.parameters.tenantID
+          value: "b2255c28-9e28-4641-a6bc-b63391d59141"
+      - equal:
+          path: spec.parameters.userAssignedIdentityID
+          value: "b2255c28-9e28-4641-a6bc-b63391d59142"
+      - equal:
+          path: spec.parameters.keyvaultName
+          value: "kv-rg00-ss0-render-dev1"
+  - it: should prefer values from key vault spec over global and default values if defined
+    templates:
+      - csi-secrets-store-azure.yaml
+    set:
+      global:
+        azureKeyVaultDefaultValues:
+          tenantId: b2255c28-9e28-4641-a6bc-b63391d59110
+          clientId: b2255c28-9e28-4641-a6bc-b63391d59120
+          kvName: kv-rg00-ss0-render-dev10
+      azureKeyVault:
+        defaultValues:
+          tenantId: b2255c28-9e28-4641-a6bc-b63391d59130
+          clientId: b2255c28-9e28-4641-a6bc-b63391d59140
+          kvName: kv-rg00-ss0-render-dev20
+        vaults:
+          myKv1:
+            tenantId: b2255c28-9e28-4641-a6bc-b63391d59141
+            clientId: b2255c28-9e28-4641-a6bc-b63391d59142
+            kvName: kv-rg00-ss0-render-dev1
+            secrets:
+              - nameInKv: "name-of-secret-in-vault"
+                fileMountPath: "/hardcoded/path/of/secret/as/file"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.parameters.tenantID
+          value: "b2255c28-9e28-4641-a6bc-b63391d59141"
+      - equal:
+          path: spec.parameters.userAssignedIdentityID
+          value: "b2255c28-9e28-4641-a6bc-b63391d59142"
+  - it: should prefer global values over default values if values are not defined for key vault spec
+    templates:
+      - csi-secrets-store-azure.yaml
+    set:
+      global:
+        azureKeyVaultDefaultValues:
+          tenantId: b2255c28-9e28-4641-a6bc-b63391d59110
+          clientId: b2255c28-9e28-4641-a6bc-b63391d59120
+          kvName: kv-rg00-ss0-render-dev10
+      azureKeyVault:
+        defaultValues:
+          tenantId: b2255c28-9e28-4641-a6bc-b63391d59130
+          clientId: b2255c28-9e28-4641-a6bc-b63391d59140
+          kvName: kv-rg00-ss0-render-dev20
+        vaults:
+          myKv1:
+            secrets:
+              - nameInKv: "name-of-secret-in-vault"
+                fileMountPath: "/hardcoded/path/of/secret/as/file"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.parameters.tenantID
+          value: "b2255c28-9e28-4641-a6bc-b63391d59110"
+      - equal:
+          path: spec.parameters.userAssignedIdentityID
+          value: "b2255c28-9e28-4641-a6bc-b63391d59120"
+      - equal:
+          path: spec.parameters.keyvaultName
+          value: "kv-rg00-ss0-render-dev10"
+  - it: should be possible to specify only global default values
+    templates:
+      - csi-secrets-store-azure.yaml
+    set:
+      global:
+        azureKeyVaultDefaultValues:
+          tenantId: b2255c28-9e28-4641-a6bc-b63391d59141
+          clientId: b2255c28-9e28-4641-a6bc-b63391d59142
+          kvName: kv-rg00-ss0-render-dev1
+      azureKeyVault:
+        defaultValues: {}
         vaults:
           myKv1:
             secrets:

--- a/charts/dsb-spring-boot/values.yaml
+++ b/charts/dsb-spring-boot/values.yaml
@@ -1,4 +1,9 @@
 ---
+# global values
+# in order to have global defaults across multiple charts, the following is supported:
+#   'global.azureKeyVaultDefaultValues' if defined will take precedence over 'azureKeyVault.defaultValues'
+global: {}
+
 # Number of pods to create:
 replicas: 2
 
@@ -59,6 +64,7 @@ configMapRefs: {}
 azureKeyVault:
   # Values that are used if not explicitly defined for the KVs in 'vaults'
   # Normally ArgoCD will define these for a given runtime environment
+  # if 'global.azureKeyVaultDefaultValues' is defined it will take precedence
   defaultValues: {}
     # tenantId: GUID # default value for tenant ID of the key vault(s)
     # clientId: GUID # default value for client id of the managed identity to use as identity when accessing key vault(s)
@@ -196,3 +202,4 @@ rbac:
 websocket:
   enabled: false
   port: 9091
+...


### PR DESCRIPTION
# changes
- feat: dsb-spring-boot: allow global override of key vault defaults
  - It is now possible to define global value `global.azureKeyVaultDefaultValues` and have it take precedence over `'azureKeyVault.defaultValues'`