### PR TITLE
fix(dsb-spring-boot): persistent storage container creation

### DIFF
--- a/charts/dsb-spring-boot/Chart.yaml
+++ b/charts/dsb-spring-boot/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.4.1
+version: 5.0.0

--- a/charts/dsb-spring-boot/templates/blobStorage.yaml
+++ b/charts/dsb-spring-boot/templates/blobStorage.yaml
@@ -24,9 +24,9 @@ parameters:
   # ref. https://learn.microsoft.com/en-us/azure/storage/blobs/blobfuse2-what-is#blobfuse2-enhancements-from-blobfuse-v1
   protocol: "fuse2"
   networkEndpointType: "privateEndpoint"
-  # can only contain lowercase letters, numbers, hyphens, and length should be less than 21
-  # we remove hyphens and truncate to 20 characters, just to be safe
-  containerNamePrefix: {{ regexReplaceAll "[^a-zA-Z0-9]" .Release.Name  "" | lower | trunc 20 | quote }}
+  # may only contain lowercase letters, numbers, and hyphens, and must begin with a letter or a number. Each hyphen
+  # must be preceded and followed by a non-hyphen character. The name must also be between 3 and 63 characters long
+  containerName: {{ regexReplaceAll "[^a-zA-Z0-9-]" .Release.Name  "" | lower | trunc 63 | quote }}
   # allow or disallow public access to all blobs or containers for storage account created by driver
   allowBlobPublicAccess: "false"
   # only used when creating new storage accounts

--- a/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
@@ -17,7 +17,7 @@ Full manifest should match snapshot:
       - --cache-size-mb=1000
     parameters:
       allowBlobPublicAccess: "false"
-      containerNamePrefix: releasename
+      containerName: release-name
       matchTags: "true"
       networkEndpointType: privateEndpoint
       protocol: fuse2
@@ -187,7 +187,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=4.4.1_config-hash=2a90c49808aeec8f55d9ddb4176d867840223010cb34a4991e63ed284b2c8eed
+            checksum: chart-version=5.0.0_config-hash=6994ead13a864052cdea73bb9f214f98ee0601546b561c9c574f910b976bb0cf
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -245,7 +245,7 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=4.4.1_config-hash=f63516af8ea53d3683dd6fcf09143e42d4b8bbb449f267f15f8566f2cb170082
+            checksum: chart-version=5.0.0_config-hash=f63516af8ea53d3683dd6fcf09143e42d4b8bbb449f267f15f8566f2cb170082
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -258,9 +258,9 @@ Full manifest should match snapshot:
             app.kubernetes.io/part-of: Verification stuff
             app.kubernetes.io/version: greatest
             azure.workload.identity/use: "true"
-            helm.sh/chart: dsb-spring-boot-4.4.1
+            helm.sh/chart: dsb-spring-boot-5.0.0
             helm.sh/chart-name: dsb-spring-boot
-            helm.sh/chart-version: 4.4.1
+            helm.sh/chart-version: 5.0.0
         spec:
           affinity:
             podAntiAffinity:
@@ -487,10 +487,10 @@ Full manifest should match snapshot:
         app.kubernetes.io/part-of: Verification stuff
         app.kubernetes.io/version: greatest
         chart-name: dsb-spring-boot
-        chart-version: 4.4.1
-        helm.sh/chart: dsb-spring-boot-4.4.1
+        chart-version: 5.0.0
+        helm.sh/chart: dsb-spring-boot-5.0.0
         helm.sh/chart-name: dsb-spring-boot
-        helm.sh/chart-version: 4.4.1
+        helm.sh/chart-version: 5.0.0
         management.port: "81"
         spring-boot: "true"
       name: RELEASE-NAME
@@ -552,7 +552,7 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=4.4.1_config-hash=660297ce85425932576dccae6bf4f1694cba5d392983346cc606cdd6af3e752c
+            checksum: chart-version=5.0.0_config-hash=660297ce85425932576dccae6bf4f1694cba5d392983346cc606cdd6af3e752c
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -565,9 +565,9 @@ Minimal manifest should match snapshot:
             app.kubernetes.io/part-of: RELEASE-NAME
             app.kubernetes.io/version: latest
             azure.workload.identity/use: "false"
-            helm.sh/chart: dsb-spring-boot-4.4.1
+            helm.sh/chart: dsb-spring-boot-5.0.0
             helm.sh/chart-name: dsb-spring-boot
-            helm.sh/chart-version: 4.4.1
+            helm.sh/chart-version: 5.0.0
         spec:
           affinity:
             podAntiAffinity:
@@ -663,10 +663,10 @@ Minimal manifest should match snapshot:
         app.kubernetes.io/part-of: RELEASE-NAME
         app.kubernetes.io/version: latest
         chart-name: dsb-spring-boot
-        chart-version: 4.4.1
-        helm.sh/chart: dsb-spring-boot-4.4.1
+        chart-version: 5.0.0
+        helm.sh/chart: dsb-spring-boot-5.0.0
         helm.sh/chart-name: dsb-spring-boot
-        helm.sh/chart-version: 4.4.1
+        helm.sh/chart-version: 5.0.0
         management.port: "8180"
         spring-boot: "true"
       name: RELEASE-NAME


### PR DESCRIPTION
# fixes
fix(dsb-spring-boot): persistent storage for deployment:
- This prevents creation of new storage container for an app each time it is freshly deployed (ex. helm uninstall + helm install)
  - Previous behavior:
    - Uninstalling + re-installing would create a new storage container in the Azure storage account backing the persistent storage claim.
    - The storage container name would consist of `<the application name>-<unique guid representing the pvc volume>`. The unique pvc volume guid was the cause of new storage containers being created.
  - Current behavior:
    - The storage container name are now hardcoded to `<the application name>`.
    - Uninstalling + re-installing will not create new storage containers each time around.
- BREAKING CHANGE: A side effect of this change is that already installed applications with an already existing storage container will have a _NEW_ storage container created and mounted, following the updated naming convention, when the chart version is bumped. Data will have to be migrated between the two manually.