### PR TITLE
chore(spring-boot): blob storage - remove deprecated pvc annotation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -26,7 +26,10 @@ jobs:
         run: helm lint charts/*
 
       - name: Run Helm Unittests
-        run: docker run --rm --name unittest --volume "$(pwd)":/apps helmunittest/helm-unittest charts/*
+        # TODO: version is pinned to '3.14.3-0.4.4' workaround
+        # bug https://github.com/helm-unittest/helm-unittest/issues/329
+        # was fixed in 'v0.5.1' but docker image is missing ref. https://github.com/helm-unittest/helm-unittest/issues/348
+        run: docker run --rm --name unittest --volume "$(pwd)":/apps helmunittest/helm-unittest:3.14.3-0.4.4 charts/*
 
       - name: log into azure container registry (ACR)
         uses: azure/docker-login@v1

--- a/charts/dsb-spring-boot/Chart.yaml
+++ b/charts/dsb-spring-boot/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.1.2
+version: 5.1.3

--- a/charts/dsb-spring-boot/templates/blobStorage.yaml
+++ b/charts/dsb-spring-boot/templates/blobStorage.yaml
@@ -55,8 +55,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: pvc-blob-storage-{{ .Release.Name }}
-  annotations:
-    volume.beta.kubernetes.io/storage-class: sc-blob-storage-{{ .Release.Name }}
 spec:
   accessModes:
     - ReadWriteMany

--- a/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
+++ b/charts/dsb-spring-boot/tests/__snapshot__/rendering_test.yaml.snap
@@ -30,8 +30,6 @@ Full manifest should match snapshot:
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
-      annotations:
-        volume.beta.kubernetes.io/storage-class: sc-blob-storage-RELEASE-NAME
       name: pvc-blob-storage-RELEASE-NAME
     spec:
       accessModes:
@@ -187,7 +185,7 @@ Full manifest should match snapshot:
       template:
         metadata:
           annotations:
-            checksum: chart-version=5.1.2_config-hash=98b985d023b78ca4dc9949dec64f66597eb25815ac49e2612bf01e77d47624ea
+            checksum: chart-version=5.1.3_config-hash=083bf07863f6248bc33231985aea217118acb34a56840099c4faa039073a3341
           labels:
             app: RELEASE-NAME-db-app
         spec:
@@ -245,7 +243,7 @@ Full manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=5.1.2_config-hash=e0678d2458f6034658a06150389218f43c8e4e3256756525d0a4529a2ce8f279
+            checksum: chart-version=5.1.3_config-hash=e0678d2458f6034658a06150389218f43c8e4e3256756525d0a4529a2ce8f279
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -258,9 +256,9 @@ Full manifest should match snapshot:
             app.kubernetes.io/part-of: Verification stuff
             app.kubernetes.io/version: greatest
             azure.workload.identity/use: "true"
-            helm.sh/chart: dsb-spring-boot-5.1.2
+            helm.sh/chart: dsb-spring-boot-5.1.3
             helm.sh/chart-name: dsb-spring-boot
-            helm.sh/chart-version: 5.1.2
+            helm.sh/chart-version: 5.1.3
         spec:
           affinity:
             podAntiAffinity:
@@ -453,9 +451,9 @@ Full manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: Rendering test
         app.kubernetes.io/part-of: Verification stuff
-        helm.sh/chart: dsb-spring-boot-5.1.2
+        helm.sh/chart: dsb-spring-boot-5.1.3
         helm.sh/chart-name: dsb-spring-boot
-        helm.sh/chart-version: 5.1.2
+        helm.sh/chart-version: 5.1.3
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -504,10 +502,10 @@ Full manifest should match snapshot:
         app.kubernetes.io/part-of: Verification stuff
         app.kubernetes.io/version: greatest
         chart-name: dsb-spring-boot
-        chart-version: 5.1.2
-        helm.sh/chart: dsb-spring-boot-5.1.2
+        chart-version: 5.1.3
+        helm.sh/chart: dsb-spring-boot-5.1.3
         helm.sh/chart-name: dsb-spring-boot
-        helm.sh/chart-version: 5.1.2
+        helm.sh/chart-version: 5.1.3
         management.port: "81"
         spring-boot: "true"
       name: RELEASE-NAME
@@ -569,7 +567,7 @@ Minimal manifest should match snapshot:
         metadata:
           annotations:
             apparmor.security.beta.kubernetes.io/pod: runtime/default
-            checksum: chart-version=5.1.2_config-hash=a852fe4f1f87db4cae8924a3cc9190d1a6d20810cb3b0739daf5977ba95e553b
+            checksum: chart-version=5.1.3_config-hash=a852fe4f1f87db4cae8924a3cc9190d1a6d20810cb3b0739daf5977ba95e553b
             co.elastic.logs/json.add_error_key: "true"
             co.elastic.logs/json.keys_under_root: "true"
             co.elastic.logs/json.overwrite_keys: "true"
@@ -582,9 +580,9 @@ Minimal manifest should match snapshot:
             app.kubernetes.io/part-of: RELEASE-NAME
             app.kubernetes.io/version: latest
             azure.workload.identity/use: "false"
-            helm.sh/chart: dsb-spring-boot-5.1.2
+            helm.sh/chart: dsb-spring-boot-5.1.3
             helm.sh/chart-name: dsb-spring-boot
-            helm.sh/chart-version: 5.1.2
+            helm.sh/chart-version: 5.1.3
         spec:
           affinity:
             podAntiAffinity:
@@ -680,10 +678,10 @@ Minimal manifest should match snapshot:
         app.kubernetes.io/part-of: RELEASE-NAME
         app.kubernetes.io/version: latest
         chart-name: dsb-spring-boot
-        chart-version: 5.1.2
-        helm.sh/chart: dsb-spring-boot-5.1.2
+        chart-version: 5.1.3
+        helm.sh/chart: dsb-spring-boot-5.1.3
         helm.sh/chart-name: dsb-spring-boot
-        helm.sh/chart-version: 5.1.2
+        helm.sh/chart-version: 5.1.3
         management.port: "8180"
         spring-boot: "true"
       name: RELEASE-NAME


### PR DESCRIPTION
# changes

- chore(spring-boot): blob storage - remove deprecated pvc annotation
- fix(ci/cd): workaround for `Error:  no asserts found`
